### PR TITLE
fix: broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Oz Workspace
 
-Oz Workspace is an open-source collaborative AI agent workspace built with [Warp's Oz API](https://docs.warp.dev/agents/oz-api). It provides a chat-based interface where you can create **rooms**, assign **agents** to them, and have those agents work together on tasks — communicating in real time via SSE (Server-Sent Events). Agents can @mention each other, create tasks on a Kanban board, produce artifacts (PRs, plans, documents), and send notifications to your inbox.
+Oz Workspace is an open-source collaborative AI agent workspace built with [Warp's Oz API](https://docs.warp.dev/reference/api-and-sdk/api-and-sdk#oz-agent-api). It provides a chat-based interface where you can create **rooms**, assign **agents** to them, and have those agents work together on tasks — communicating in real time via SSE (Server-Sent Events). Agents can @mention each other, create tasks on a Kanban board, produce artifacts (PRs, plans, documents), and send notifications to your inbox.
 
 ## Key Concepts
 


### PR DESCRIPTION
https://docs.warp.dev/agent-platform#getting-started
> [Oz Agent API & SDK](https://docs.warp.dev/reference/api-and-sdk/agent) - Programmatically create and monitor agent runs

that should probably also link to https://docs.warp.dev/reference/api-and-sdk/api-and-sdk instead