### PR TITLE
fix: update hono to 4.12.25 to resolve CVE-2026-54290 and related CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8677,9 +8677,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "overrides": {
     "@hono/node-server": "1.19.13",
+    "hono": "4.12.25",
     "postcss": "8.5.10",
     "esbuild": "0.28.1"
   }


### PR DESCRIPTION
Bumps transitive dependency `hono` from 4.12.23 → 4.12.25 via npm `overrides` in `package.json`.

## Vulnerabilities resolved

| Alert | CVE | Severity | Summary |
|-------|-----|----------|---------|
| [#95](https://github.com/warpdotdev/oz-workspace/security/dependabot/95) | CVE-2026-54290 | High (7.1) | CORS middleware reflects any Origin with credentials when `origin` defaults to wildcard |
| [#94](https://github.com/warpdotdev/oz-workspace/security/dependabot/94) | CVE-2026-54286 | Moderate (5.9) | Path traversal in `serve-static` on Windows via encoded backslash (`%5C`) |
| [#97](https://github.com/warpdotdev/oz-workspace/security/dependabot/97) | CVE-2026-54288 | Moderate (6.5) | Body Limit Middleware bypass on AWS Lambda by understating `Content-Length` |
| [#93](https://github.com/warpdotdev/oz-workspace/security/dependabot/93) | CVE-2026-54287 | Moderate (5.3) | AWS Lambda adapter merges multiple `Set-Cookie` headers into one value |
| [#96](https://github.com/warpdotdev/oz-workspace/security/dependabot/96) | CVE-2026-54289 | Moderate (4.8) | Lambda@Edge adapter drops repeated request headers |

Advisory: https://github.com/advisories/GHSA-88fw-hqm2-52qc

## What changed

Added `"hono": "4.12.25"` to the `overrides` field in `package.json`. This forces npm to resolve `hono` (a peer dependency of `@hono/node-server`) to the patched version.

## Verification

`npm audit` confirms all 5 hono CVEs are cleared. Remaining open alerts (`@babel/core`, `js-yaml`) are separate issues not addressed in this PR.

_Conversation: https://staging.warp.dev/conversation/9dd33977-7d60-4216-adf1-d7d823bae9df_
_Run: https://oz.staging.warp.dev/runs/019eef6c-8fbc-756c-9490-884c7af5ca1b_
_This PR was generated with [Oz](https://warp.dev/oz)._
