### PR TITLE
fix: pin js-yaml to 4.2.0 to resolve CVE-2026-53550

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9534,9 +9534,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "overrides": {
     "@hono/node-server": "1.19.13",
+    "js-yaml": "4.2.0",
     "postcss": "8.5.10",
     "esbuild": "0.28.1"
   }


### PR DESCRIPTION
Pins `js-yaml` to 4.2.0 via npm `overrides` to resolve CVE-2026-53550.

**Advisory:** https://github.com/advisories/GHSA-h67p-54hq-rp68
**Dependabot alert:** https://github.com/warpdotdev/oz-workspace/security/dependabot/92

**Vulnerability:** JS-YAML quadratic-complexity DoS in merge key handling via repeated aliases (CVSS 5.3, moderate).

**Fix:** Added `"js-yaml": "4.2.0"` to the `overrides` field in `package.json`. The patched version (4.2.0) satisfies all transitive consumers (`@eslint/eslintrc ^4.1.1` and `cosmiconfig ^4.1.0`).

**Verification:** `npm audit` no longer reports GHSA-h67p-54hq-rp68 / CVE-2026-53550.

_This PR was generated with [Oz](https://warp.dev/oz)._
